### PR TITLE
Blazemeter/jmeter-http2-plugin release v2.0.6

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -952,6 +952,26 @@
           "jetty-io>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.5/jetty-io-11.0.15.jar",
           "jetty-util>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.5/jetty-util-11.0.15.jar"
         }
+      },
+      "2.0.6": {
+        "changes": "Plugin rebranding",
+        "downloadUrl": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jmeter-bzm-http2-2.0.6.jar",
+        "libs": {
+          "http2-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/http2-client-11.0.15.jar",
+          "http2-common>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/http2-common-11.0.15.jar",
+          "http2-hpack>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/http2-hpack-11.0.15.jar",
+          "http2-http-client-transport>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/http2-http-client-transport-11.0.15.jar",
+          "jetty-alpn-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jetty-alpn-client-11.0.15.jar",
+          "jetty-alpn-java-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jetty-alpn-java-client-11.0.15.jar",
+          "jetty-client>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jetty-client-11.0.15.jar",
+          "jetty-http>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jetty-http-11.0.15.jar",
+          "jetty-io>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jetty-io-11.0.15.jar",
+          "jetty-util>=11.0.15": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jetty-util-11.0.15.jar",
+          "jmeter-bzm-commons>=0.2.3": "https://github.com/Blazemeter/jmeter-http2-plugin/releases/download/v2.0.6/jmeter-bzm-commons-0.2.3.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
### What's new:
- This release includes the usage of the [jmeter-bzm-commons](https://github.com/Blazemeter/jmeter-bzm-commons)
   - A module that enables to reuse logic shared along all BlazeMeter maintained plugins
