### PR TITLE
Blazemeter/HLSPlugin release v3.2

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -631,6 +631,24 @@
         "depends": [
           "jmeter-http"
         ]
+      },
+      "3.2": {
+        "changes": "HLS Release note",
+        "downloadUrl": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/jmeter-bzm-hls-3.2.jar",
+        "libs": {
+          "hlsparserj>=1.0.1": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/hlsparserj-1.0.1.jar",
+          "jackson-annotations>=2.10.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/jackson-annotations-2.10.2.jar",
+          "jackson-core>=2.10.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/jackson-core-2.10.2.jar",
+          "jackson-databind>=2.10.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/jackson-databind-2.10.2.jar",
+          "jackson-dataformat-xml>=2.10.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/jackson-dataformat-xml-2.10.2.jar",
+          "jackson-module-jaxb-annotations>=2.10.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/jackson-module-jaxb-annotations-2.10.2.jar",
+          "mpd-parser>=0.8-jdk8": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/mpd-parser-0.8-jdk8.jar",
+          "stax2-api>=4.2": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/stax2-api-4.2.jar",
+          "woodstox-core>=5.3.0": "https://github.com/Blazemeter/HLSPlugin/releases/download/v3.2/woodstox-core-5.3.0.jar"
+        },
+        "depends": [
+          "jmeter-http"
+        ]
       }
     }
   },


### PR DESCRIPTION
In this release, the following features were added:
- Added option to include video type in request response headers
- Added dropdown selection for resolution, bandwidth, audio and subitles. Also added a load playlist button
- Added base for variant download
- Support use of ByteRange label for fragmented media playlists
- Update JMeter Compatibility up to 5.5

Also, the following are fixes or changes to prevent potential errors:
- Fixed issue where resolution is null and it attempts to evaluate it as a dictionary
- Start using local library to get EXT-X-MAP
- Return specific error in sampler if selected bandwidth or resolution doesn't exist
- Fix updating redirection uri when Master Playlist has redirection
- hls docker generation
- Fix issue when playlists use relative paths
- Fix issue when resolution field is not present
- Fix issue when language field is not present

The documentation was updated to represent new views and options