### PR TITLE
Fix blazemeter.json for Citrix Plugin

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -1660,7 +1660,6 @@
       "0.7.8": {
         "changes": "BlazeMeter rebranding",
         "downloadUrl": "https://github.com/Blazemeter/CitrixPlugin/releases/download/0.7.8/citrix-jmeter-0.7.8.jar",
-        "libs": {},
         "depends": [
           "jmeter-core",
           "jmeter-components",


### PR DESCRIPTION
The fix it's related with the issue reported in https://github.com/undera/jmeter-plugins/pull/727#issuecomment-2965733934

Apologies for causing this issue.

