### PR TITLE
Blazemeter/RTEPlugin release v3.3.1

### DIFF
--- a/site/dat/repo/blazemeter.json
+++ b/site/dat/repo/blazemeter.json
@@ -1180,6 +1180,17 @@
           "dm3270-lib>=0.15": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.2.2/dm3270-lib-0.15.jar",
           "jVT220>=1.3.2": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.3/jVT220-1.3.2.jar"
         }
+      },
+      "3.3.1": {
+        "changes": "BlazeMeter rebranding",
+        "downloadUrl": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.3.1/jmeter-bzm-rte-3.3.1.jar",
+        "libs": {
+          "dm3270-lib>=0.15": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.3.1/dm3270-lib-0.15.jar",
+          "jmeter-bzm-commons>=0.2.4": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.3.1/jmeter-bzm-commons-0.2.4.jar",
+          "jVT220>=1.3.2": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.3.1/jVT220-1.3.2.jar",
+          "xtn5250>=3.2.4": "https://github.com/Blazemeter/RTEPlugin/releases/download/v3.3.1/xtn5250-3.2.4.jar"
+        },
+        "depends": []
       }
     }
   },


### PR DESCRIPTION
***What's new on this patch release:***
- BlazeMeter Rebranding
- Documentation updated to impact BlazeMeter rebrand
- Icons in the Terminal Emulator have now been restored
- Automatic deployment to JMeter Plugins enabled
- Automatic deployment to Maven Central enabled


**Traceable Changelog:**

* Release v3.3.1 by @Baraujo25 in https://github.com/Blazemeter/RTEPlugin/pull/44
* Comply with maven central requirements for deployment by @Baraujo25 in https://github.com/Blazemeter/RTEPlugin/pull/46
* Add jmeter plugin publish action by @Baraujo25 in https://github.com/Blazemeter/RTEPlugin/pull/45


**Full Changelog**: https://github.com/Blazemeter/RTEPlugin/compare/v3.3...v3.3.1